### PR TITLE
fix(about): Remove unnecessary scrollbar.

### DIFF
--- a/res/styles/index.css
+++ b/res/styles/index.css
@@ -59,8 +59,8 @@ body {
     width: 80%;
     height:100vh;
     background-color: rgba(12, 12, 12, 0.8);
-    overflow:visible;
-    overflow-x:scroll;
+    overflow-x: hidden;
+    overflow-y: auto;
 }
 #tooltip_menu {
     position:absolute;
@@ -82,7 +82,7 @@ body {
     height:28%;
 }
 #top_menu:hover .top_menu_button {
-    
+
 }
 .top_menu_button {
     top:0px;


### PR DESCRIPTION
The horizontal scrollbar isn't necessary since the navigation
bar will animate the "about" section to the right content.

Before:
![image](https://user-images.githubusercontent.com/7005773/54320904-eb3edb00-45ab-11e9-89d7-c3239de80052.png)

After:
![image](https://user-images.githubusercontent.com/7005773/54320919-fa258d80-45ab-11e9-814b-e002d4abdbb2.png)

-----

It also looks like my editor removed some unnecessary whitespace 😀